### PR TITLE
Update SecurityConfig.java

### DIFF
--- a/discovery-server/src/main/java/com/programming/techie/discoveryserver/SecurityConfig.java
+++ b/discovery-server/src/main/java/com/programming/techie/discoveryserver/SecurityConfig.java
@@ -1,15 +1,44 @@
 package com.programming.techie.discoveryserver;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 public class SecurityConfig {
+
+    @Value("${spring.security.user.name}")
+    private String username;
+    @Value("${spring.security.user.password}")
+    private String password;
+
+    @Bean
+    public UserDetailsService users() {
+        UserDetails user = User.builder()
+                .username(username)
+                .password("{noop}" + password)
+                .roles("USER")
+                .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
-        httpSecurity.csrf().ignoringRequestMatchers("/eureka/**");
+        httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> {
+                    auth.requestMatchers("/eureka/**").permitAll();
+                    auth.anyRequest().authenticated();
+                })
+                .httpBasic(Customizer.withDefaults());
         return httpSecurity.build();
     }
 }


### PR DESCRIPTION
This update replaces nearly deprecated methods with safe ones. It also adds security to the Discovery Service so that credentials in the application.properties file are supplied when accessing localhost:8761